### PR TITLE
Update model.json for LTC016 Aurelle round

### DIFF
--- a/custom_components/powercalc/data/signify/LTC016/model.json
+++ b/custom_components/powercalc/data/signify/LTC016/model.json
@@ -9,5 +9,8 @@
         "VERSION": "master"
     },
     "name": "Hue Aurelle Round Panel Light",
-    "standby_power": 0.47
+    "standby_power": 0.47,
+  "aliases": [
+      "3216431P6"
+  ]
 }


### PR DESCRIPTION
Update model.json for LTC016 Aurelle round

AURELLE ROUND CEILING LIVING via z2m
2024-03-14 21:54:17.781 DEBUG (MainThread) [custom_components.powercalc.discovery] light.living_ceiling: Auto discovered model (manufacturer=Signify Netherlands B.V., model=Hue Aurelle (3216431P6))
2024-03-14 21:54:17.841 DEBUG (MainThread) [custom_components.powercalc.discovery] light.living_ceiling: Model not found in library, skipping discovery